### PR TITLE
Add basic styled frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+.DS_Store

--- a/frontend/src/components/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  type?: 'info' | 'warning' | 'error' | 'success';
+  children: ReactNode;
+}
+
+export default function AlertBanner({ type = 'info', children }: Props) {
+  return <div className={`alert alert-${type}`}>{children}</div>;
+}

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  variant?: 'safe' | 'phishing' | 'warning';
+  children: ReactNode;
+}
+
+export default function Badge({ variant = 'safe', children }: Props) {
+  return <span className={`badge badge-${variant}`}>{children}</span>;
+}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger';
+}
+
+export default function Button({ variant = 'primary', className = '', ...props }: Props) {
+  const variantClass = `btn btn-${variant}`;
+  return <button className={`${variantClass} ${className}`} {...props} />;
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+export default function Card({ title, children, footer }: Props) {
+  return (
+    <div className="card">
+      {title && <h3>{title}</h3>}
+      <div>{children}</div>
+      {footer && <div className="mt-2">{footer}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,7 +1,31 @@
 export default function Chat() {
   return (
-    <div className="border rounded p-2">
-      <p>Chat component placeholder.</p>
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <aside className="inbox">
+        <div className="email-item">
+          <span>📧</span>
+          <span style={{ marginLeft: '0.5rem' }}>Email 1</span>
+        </div>
+        <div className="email-item">
+          <span>📧</span>
+          <span style={{ marginLeft: '0.5rem' }}>Email 2</span>
+        </div>
+        <div className="email-item">
+          <span>📧</span>
+          <span style={{ marginLeft: '0.5rem' }}>Email 3</span>
+        </div>
+      </aside>
+      <section className="chat-panel">
+        <div className="chat-messages">
+          <div className="chat-bubble user">Is this phishing?</div>
+          <div className="chat-bubble bot">
+            Yes, risk score 87%. Domain mismatch detected.
+          </div>
+        </div>
+        <div className="chat-input">
+          <input style={{ width: '100%', padding: '0.5rem' }} placeholder="Type a message" />
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,18 @@
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/frontend/src/pages/chat.tsx
+++ b/frontend/src/pages/chat.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head';
+import Chat from '../components/Chat';
+
+export default function ChatPage() {
+  return (
+    <>
+      <Head>
+        <title>ScamMail AI - Chat</title>
+      </Head>
+      <Chat />
+    </>
+  );
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,0 +1,23 @@
+import Head from 'next/head';
+import Card from '../components/Card';
+import AlertBanner from '../components/AlertBanner';
+
+export default function Dashboard() {
+  return (
+    <>
+      <Head>
+        <title>ScamMail AI - Dashboard</title>
+      </Head>
+      <main style={{ padding: '1rem' }}>
+        <h1>Dashboard</h1>
+        <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))' }}>
+          <Card title="Total Scans">123</Card>
+          <Card title="Phishing Rate">45%</Card>
+          <Card title="Avg. Confidence">87%</Card>
+          <Card title="False Positives">2%</Card>
+        </div>
+        <AlertBanner type="info">Charts would appear here.</AlertBanner>
+      </main>
+    </>
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,14 +1,23 @@
 import Head from 'next/head';
+import Link from 'next/link';
 
 export default function Home() {
   return (
     <>
       <Head>
-        <title>Gmail Scam Analyzer</title>
+        <title>ScamMail AI</title>
       </Head>
-      <main className="p-4">
-        <h1 className="text-2xl font-bold">Gmail Scam Analyzer Chatbot</h1>
+      <main style={{ padding: '1rem' }}>
+        <h1 className="text-2xl font-bold">ScamMail AI</h1>
         <p className="mt-2">Front page placeholder.</p>
+        <div style={{ marginTop: '1rem' }}>
+          <Link href="/chat" legacyBehavior>
+            <a className="btn btn-primary" style={{ marginRight: '0.5rem' }}>Open Chat</a>
+          </Link>
+          <Link href="/dashboard" legacyBehavior>
+            <a className="btn btn-secondary">Dashboard</a>
+          </Link>
+        </div>
       </main>
     </>
   );

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,144 @@
+:root {
+  --font-sans: 'Inter', sans-serif;
+  --font-body: 'Roboto', sans-serif;
+  --color-primary: #2C7BE5;
+  --color-accent: #26C6DA;
+  --color-neutral-bg: #F7F9FC;
+  --color-text-secondary: #6E7381;
+  --color-danger: #E55353;
+  --color-warning: #F6C343;
+}
+
+html, body {
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-body);
+  background-color: var(--color-neutral-bg);
+  color: #000;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-sans);
+}
+
+button {
+  cursor: pointer;
+  transition: background-color 150ms ease-in-out;
+}
+
+button:hover:not([disabled]) {
+  filter: brightness(1.1);
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-weight: 600;
+  border: none;
+}
+
+.btn-primary {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.btn-secondary {
+  background-color: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+
+.btn-danger {
+  background-color: var(--color-danger);
+  color: white;
+}
+
+.card {
+  background: white;
+  border-radius: 6px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: white;
+}
+
+.badge-safe { background: var(--color-primary); }
+.badge-phishing { background: var(--color-danger); }
+.badge-warning { background: var(--color-warning); color: #000; }
+
+.alert {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.alert-info { background: var(--color-primary); color: white; }
+.alert-warning { background: var(--color-warning); color: #000; }
+.alert-error { background: var(--color-danger); color: white; }
+.alert-success { background: var(--color-accent); color: white; }
+
+.inbox {
+  width: 240px;
+  border-right: 1px solid #e5e5e5;
+  overflow-y: auto;
+}
+
+.email-item {
+  padding: 0.5rem;
+  border-bottom: 1px solid #e5e5e5;
+  display: flex;
+  align-items: center;
+  transition: background-color 150ms ease-in-out;
+}
+
+.email-item:hover {
+  background-color: #f0f0f0;
+}
+
+.chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px);
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.chat-input {
+  border-top: 1px solid #e5e5e5;
+  padding: 0.5rem;
+  background: white;
+}
+
+.chat-bubble {
+  margin-bottom: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  max-width: 70%;
+}
+
+.chat-bubble.user {
+  background: var(--color-accent);
+  color: white;
+  align-self: flex-end;
+}
+
+.chat-bubble.bot {
+  background: #e5e5e5;
+  color: #000;
+  align-self: flex-start;
+}
+


### PR DESCRIPTION
## Summary
- implement global design tokens and basic styles
- add reusable UI components (Button, Card, Badge, AlertBanner)
- create chat and dashboard pages using new components
- update home page with navigation links
- inject fonts and styles via `_app.tsx`

## Testing
- `npm --prefix frontend run build`