### PR TITLE
Add Gmail token persistence

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "googleapis": "^118.0.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.6.5",
         "reflect-metadata": "^0.1.13",
@@ -1284,6 +1285,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -1452,6 +1488,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -1492,6 +1537,15 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2580,6 +2634,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -2614,6 +2674,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "license": "Apache-2.0"
     },
     "node_modules/fflate": {
       "version": "0.8.2",
@@ -2821,6 +2887,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -2940,6 +3034,105 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
+      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.3.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "deprecated": "Package is no longer maintained",
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "118.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-118.0.0.tgz",
+      "integrity": "sha512-Ny6zJOGn5P/YDT6GQbJU6K0lSzEu4Yuxnsn45ZgBIeSQ1RM0FolEjUToLXquZd89DU9wUfqA5XYHPEctk1TFWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^8.0.2",
+        "googleapis-common": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-6.0.4.tgz",
+      "integrity": "sha512-m4ErxGE8unR1z0VajT6AYk3s6a9gIMM6EkDZfkPnES8joeOlEtFEJeF8IyZkb0tjPXkktUfYrE4b3Li1DNyOwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^5.0.1",
+        "google-auth-library": "^8.0.2",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2958,6 +3151,41 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/gtoken/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3039,6 +3267,42 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -3216,6 +3480,18 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3307,6 +3583,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -3811,6 +4096,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-releases": {
@@ -5353,6 +5647,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5601,6 +5901,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.0",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "googleapis": "^118.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,8 @@ import { EmailAnalysis } from './entities/email-analysis.entity';
 import { ChatSession } from './entities/chat-session.entity';
 import { ChatMessage } from './entities/chat-message.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { GmailToken } from './entities/gmail-token.entity';
+import { GmailService } from './services/gmail.service';
 
 @Module({
   imports: [
@@ -24,7 +26,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
       isGlobal: true,
     }),
     TypeOrmModule.forRoot(databaseConfig),
-    TypeOrmModule.forFeature([User, EmailAnalysis, ChatSession, ChatMessage, RefreshToken]),
+    TypeOrmModule.forFeature([User, EmailAnalysis, ChatSession, ChatMessage, RefreshToken, GmailToken]),
   ],
   controllers: [
     AppController,
@@ -38,7 +40,8 @@ import { RefreshToken } from './entities/refresh-token.entity';
     AuthService, 
     UserService, 
     EmailAnalysisService, 
-    ChatService
+    ChatService,
+    GmailService
   ],
 })
 export class AppModule {}

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -4,6 +4,7 @@ import { EmailAnalysis } from '../entities/email-analysis.entity';
 import { ChatSession } from '../entities/chat-session.entity';
 import { ChatMessage } from '../entities/chat-message.entity';
 import { RefreshToken } from '../entities/refresh-token.entity';
+import { GmailToken } from '../entities/gmail-token.entity';
 
 export const databaseConfig: TypeOrmModuleOptions = {
   type: 'mysql',
@@ -12,7 +13,7 @@ export const databaseConfig: TypeOrmModuleOptions = {
   username: process.env.DB_USERNAME || 'appuser',
   password: process.env.DB_PASSWORD || 'apppassword',
   database: process.env.DB_DATABASE || 'gmail_scam_analyzer',
-  entities: [User, EmailAnalysis, ChatSession, ChatMessage, RefreshToken],
+  entities: [User, EmailAnalysis, ChatSession, ChatMessage, RefreshToken, GmailToken],
   synchronize: false, // Set to false in production
   logging: process.env.NODE_ENV === 'development',
   retryAttempts: 3,

--- a/backend/src/entities/gmail-token.entity.ts
+++ b/backend/src/entities/gmail-token.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryColumn, Column, OneToOne, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('gmail_tokens')
+export class GmailToken {
+  @PrimaryColumn({ name: 'user_id' })
+  userId: string;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ name: 'access_token', type: 'text' })
+  accessToken: string;
+
+  @Column({ name: 'refresh_token', type: 'text' })
+  refreshToken: string;
+
+  @Column({ name: 'expiry_date', type: 'bigint' })
+  expiryDate: number;
+}

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -22,7 +22,22 @@ export class GmailService {
 
   async getOAuthClient(userId: string): Promise<OAuth2Client> {
     const client = this.createClient();
-    const token = await this.gmailTokenRepo.findOne({ where: { userId } });
+async getOAuthClient(userId: string): Promise<OAuth2Client> {
+    const client = this.createClient();
+    // Import and use a validation library like 'validator'
+    // validator.isUUID() checks if the input is a valid UUID
+    if (validator.isUUID(userId)) {
+      const token = await this.gmailTokenRepo.findOne({ where: { userId } });
+      if (token) {
+        client.setCredentials({
+          access_token: token.accessToken,
+          refresh_token: token.refreshToken,
+          expiry_date: token.expiryDate,
+        });
+      }
+    }
+    return client;
+  }
     if (token) {
       client.setCredentials({
         access_token: token.accessToken,

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -99,7 +99,19 @@ async saveTokens(userId: string, tokens: Auth.Credentials): Promise<void> {
     if (!record) {
       record = this.gmailTokenRepo.create({
         userId,
-        accessToken: tokens.access_token!,
+if (!record) {
+      record = this.gmailTokenRepo.create({
+        userId,
+        accessToken: tokens.access_token ?? '',
+        refreshToken: tokens.refresh_token ?? '',
+        expiryDate,
+      });
+    } else {
+      record.accessToken = tokens.access_token ?? '';
+      record.refreshToken = tokens.refresh_token ?? '';
+      record.expiryDate = expiryDate;
+    }
+    await this.gmailTokenRepo.save(record);
         refreshToken: tokens.refresh_token!,
         expiryDate,
       });

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -116,8 +116,8 @@ if (!record) {
         expiryDate,
       });
     } else {
-      record.accessToken = tokens.access_token!;
-      record.refreshToken = tokens.refresh_token!;
+      record.accessToken = tokens.access_token; // Ensure this is handled if null/undefined
+      record.refreshToken = tokens.refresh_token; // Ensure this is handled if null/undefined. Consider only updating if a new one is provided.
       record.expiryDate = expiryDate;
     }
     await this.gmailTokenRepo.save(record);

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -33,7 +33,32 @@ export class GmailService {
     return client;
   }
 
+}
+
   async saveTokens(userId: string, tokens: Auth.Credentials): Promise<void> {
+    try {
+      let record = await this.gmailTokenRepo.findOne({ where: { userId } });
+      const expiryDate = tokens.expiry_date ?? 0;
+      if (!record) {
+        record = this.gmailTokenRepo.create({
+          userId,
+          accessToken: tokens.access_token!,
+          refreshToken: tokens.refresh_token!,
+          expiryDate,
+        });
+      } else {
+        record.accessToken = tokens.access_token!;
+        record.refreshToken = tokens.refresh_token!;
+        record.expiryDate = expiryDate;
+      }
+      await this.gmailTokenRepo.save(record);
+    } catch (error) {
+      console.error('Error saving tokens:', error);
+      throw new Error('Failed to save tokens');
+    }
+  }
+
+  async handleOAuthCallback(userId: string, code: string): Promise<Auth.Credentials> {
     let record = await this.gmailTokenRepo.findOne({ where: { userId } });
     const expiryDate = tokens.expiry_date ?? 0;
     if (!record) {

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { google, Auth } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GmailToken } from '../entities/gmail-token.entity';
+
+@Injectable()
+export class GmailService {
+  private createClient(): OAuth2Client {
+    return new google.auth.OAuth2(
+      process.env.GMAIL_CLIENT_ID,
+      process.env.GMAIL_CLIENT_SECRET,
+      process.env.GMAIL_REDIRECT_URI,
+    );
+  }
+
+  constructor(
+    @InjectRepository(GmailToken)
+    private gmailTokenRepo: Repository<GmailToken>,
+  ) {}
+
+  async getOAuthClient(userId: string): Promise<OAuth2Client> {
+    const client = this.createClient();
+    const token = await this.gmailTokenRepo.findOne({ where: { userId } });
+    if (token) {
+      client.setCredentials({
+        access_token: token.accessToken,
+        refresh_token: token.refreshToken,
+        expiry_date: token.expiryDate,
+      });
+    }
+    return client;
+  }
+
+  async saveTokens(userId: string, tokens: Auth.Credentials): Promise<void> {
+    let record = await this.gmailTokenRepo.findOne({ where: { userId } });
+    const expiryDate = tokens.expiry_date ?? 0;
+    if (!record) {
+      record = this.gmailTokenRepo.create({
+        userId,
+        accessToken: tokens.access_token!,
+        refreshToken: tokens.refresh_token!,
+        expiryDate,
+      });
+    } else {
+      record.accessToken = tokens.access_token!;
+      record.refreshToken = tokens.refresh_token!;
+      record.expiryDate = expiryDate;
+    }
+    await this.gmailTokenRepo.save(record);
+  }
+
+  async handleOAuthCallback(userId: string, code: string): Promise<Auth.Credentials> {
+    const client = this.createClient();
+    const { tokens } = await client.getToken(code);
+    await this.saveTokens(userId, tokens);
+    return tokens;
+  }
+}

--- a/infrastructure/init-scripts/01-init.sql
+++ b/infrastructure/init-scripts/01-init.sql
@@ -52,6 +52,15 @@ CREATE TABLE IF NOT EXISTS chat_messages (
     INDEX idx_created_at (created_at)
 );
 
+-- Create gmail_tokens table for storing OAuth credentials
+CREATE TABLE IF NOT EXISTS gmail_tokens (
+    user_id VARCHAR(36) PRIMARY KEY,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NOT NULL,
+    expiry_date BIGINT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 -- Insert mock users (passwords are hashed for 'password123')
 INSERT INTO users (id, email, name, password) VALUES 
 ('550e8400-e29b-41d4-a716-446655440001', 'john.doe@example.com', 'John Doe', '$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LeANh0pnEP1Hc8Oz6'),


### PR DESCRIPTION
## Summary
- add `gmail_tokens` table
- create GmailToken entity and GmailService
- register GmailToken in database config and module
- allow saving Gmail OAuth tokens
- include googleapis in backend deps

## Testing
- `npm run build` *(fails: Found 59 error(s))*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced secure storage and management of Gmail OAuth tokens for users.
  - Added support for handling OAuth token authorization and retrieval.

- **Refactor**
  - Updated Gmail integration to focus on token management, removing previous email import logic.

- **Chores**
  - Updated dependencies to include the Google APIs package.
  - Enhanced database schema to support Gmail token storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->