### PR TITLE
Fix duplicate refresh token call

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -159,14 +159,9 @@ export class AuthController {
     try {
       const { token, refreshToken: newRefresh, expiresAt } = await this.authService.refreshToken(refreshToken);
       return { accessToken: token, refreshToken: newRefresh, expiresAt };
-const { token, refreshToken: newRefresh, expiresAt } = await this.authService.refreshToken(refreshToken);
-      return { accessToken: token, refreshToken: newRefresh, expiresAt };
     } catch (error) {
       // Log the error details for debugging
       console.error('Error refreshing token:', error);
-      throw new UnauthorizedException('Invalid or expired refresh token');
-    }
-  }
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
   }


### PR DESCRIPTION
## Summary
- clean up duplicated refreshToken logic in AuthController

## Testing
- `npm run build` *(fails: TypeScript errors)*