### PR TITLE
Update README with backend install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ This project consists of three main components:
    cd ../backend && npm install
    
    # Install AI service dependencies
+
    cd ../ai_service && pip install -r requirements.txt
    ```
+
+   > **Note**: Run `npm ci` inside the `backend/` directory before executing
+   > `npm run build` or any backend tests. This ensures dependencies exactly
+   > match the lock file. If the Nest CLI isn't available globally, use
+   > `npx nest build` in your scripts.
 
 2. **Start all services:**
    ```bash


### PR DESCRIPTION
## Summary
- highlight running `npm ci` in `backend/` before build or tests
- mention using `npx nest build` if Nest CLI isn't global

## Testing
- `npm ci`
- `npm run build` *(fails: Found 51 errors)*