### PR TITLE
Sync Gmail env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ JWT_SECRET=your-jwt-secret-key
 GOOGLE_CLIENT_ID=<your_google_client_id>
 GOOGLE_CLIENT_SECRET=<your_google_client_secret>
 GOOGLE_REDIRECT_URI=http://localhost:3001/oauth2callback
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=<your_google_client_id>
 ```
 
 ### Gmail API Setup

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -19,9 +19,9 @@ export class GmailService {
 
   private createClient(): OAuth2Client {
     return new google.auth.OAuth2(
-      process.env.GMAIL_CLIENT_ID,
-      process.env.GMAIL_CLIENT_SECRET,
-      process.env.GMAIL_REDIRECT_URI,
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      process.env.GOOGLE_REDIRECT_URI,
     );
   }
 

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
 NEXT_PUBLIC_AI_SERVICE_URL=http://localhost:8000
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=<your_google_client_id>


### PR DESCRIPTION
## Summary
- standardize Gmail OAuth environment variable names across the project
- document Google client env vars for frontend

## Testing
- `./test-services.sh` *(fails: AI, backend, and frontend not responding)*
- `npm run build` in `backend` *(fails: invalid package.json)*
- `npm run build` in `frontend` *(fails: `next` not found)*